### PR TITLE
Fixed reference to scss file for inline compass install.

### DIFF
--- a/templates/project/manifest.rb
+++ b/templates/project/manifest.rb
@@ -1,2 +1,2 @@
 # Make sure you list all the project template files here in the manifest.
-stylesheet 'screen.sass', :media => 'screen, projection'
+stylesheet 'screen.scss', :media => 'screen, projection'


### PR DESCRIPTION
When I ran the `compass install compass-css-arrow` command from the readme for inline install (in my case, for a jekyll project, and using `--trace`), I was getting this error:

```
 Errno::ENOENT on line ["95"] of ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/installers/base.rb: No such file or directory @ rb_sysopen - /Users/steveschwartz/.rvm/gems/ruby-2.2.3/bundler/gems/compass-css-arrow-7bd26ae62fb2/templates/project/screen.sass
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/installers/base.rb:95:in `new'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/installers/base.rb:95:in `install_stylesheet'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/installers/manifest_installer.rb:39:in `block in install'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/installers/manifest.rb:112:in `block in each'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/installers/manifest.rb:112:in `each'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/installers/manifest.rb:112:in `each'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/installers/manifest_installer.rb:38:in `install'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/installers/base.rb:33:in `run'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/commands/stamp_pattern.rb:75:in `perform'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/commands/base.rb:18:in `execute'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/commands/project_base.rb:19:in `execute'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/exec/sub_command_ui.rb:43:in `perform!'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/lib/compass/exec/sub_command_ui.rb:15:in `run!'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/bin/compass:30:in `block in <top (required)>'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/bin/compass:44:in `call'
  ~/.rvm/gems/ruby-2.2.3/gems/compass-1.0.3/bin/compass:44:in `<top (required)>'
  ~/.rvm/gems/ruby-2.2.3/bin/compass:23:in `load'
  ~/.rvm/gems/ruby-2.2.3/bin/compass:23:in `<main>'
  ~/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `eval'
  ~/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `<main>'
```

This fixes that issue.
